### PR TITLE
docs: remove the pdf button

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,7 +71,7 @@ html_show_sphinx = False
     html_logo,
     html_theme_options,
     html_context
-) = antmicro_html(pdf_url=f"{basic_filename}.pdf")
+) = antmicro_html()
 
 html_title = project
 


### PR DESCRIPTION
We don't generate the pdf docs here anyway, so the button responds with 404